### PR TITLE
feat(api): add GET /api/version endpoint (TEAM-439)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "your-repo",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "^18",
+    "react-dom": "^18"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "typescript": "^5"
+  }
+}

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import pkg from '../../../../package.json';
+
+export async function GET() {
+  return NextResponse.json({
+    version: pkg.version,
+    buildTime: new Date().toISOString(),
+    nodeVersion: process.version,
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Implements `GET /api/version` endpoint as a Next.js App Router route handler.

Closes TEAM-439 | Part of epic TEAM-434

---

## Changes

### New files
| File | Purpose |
|------|---------|
| `src/app/api/version/route.ts` | The API route handler |
| `package.json` | Next.js project scaffold (no new deps beyond Next.js framework) |
| `tsconfig.json` | TypeScript config with `resolveJsonModule: true` for package.json import |

### Route handler (`src/app/api/version/route.ts`)
```typescript
import { NextResponse } from 'next/server';
import pkg from '../../../../package.json';

export async function GET() {
  return NextResponse.json({
    version: pkg.version,
    buildTime: new Date().toISOString(),
    nodeVersion: process.version,
  });
}
```

---

## Response Shape

`GET /api/version` → HTTP 200 `application/json`

```json
{
  "version": "1.0.0",
  "buildTime": "2026-05-22T22:22:00.000Z",
  "nodeVersion": "v20.11.0"
}
```

---

## Acceptance Criteria

- [x] `GET /api/version` returns HTTP 200
- [x] Response `version` matches `package.json` version field (`"1.0.0"`)
- [x] Response `buildTime` is a valid ISO 8601 string (`new Date().toISOString()` at request time)
- [x] Response `nodeVersion` matches `process.version`
- [x] Response `Content-Type` is `application/json` (via `NextResponse.json()`)
- [x] No new npm packages — only Next.js framework APIs used
- [x] File at exactly `src/app/api/version/route.ts`
- [x] Non-GET methods return 405 automatically (Next.js App Router convention: only exported methods are handled)

---

## Implementation Notes

- Uses `NextResponse.json()` from `next/server` — sets `Content-Type: application/json` automatically
- `package.json` imported via direct relative path (`../../../../package.json`) — enabled by `"resolveJsonModule": true` in `tsconfig.json`
- Only `GET` is exported; Next.js App Router returns 405 for any method without a named export
- Zero external service calls, zero authentication, single file

---

## Workflow
- workflow_id: `wf_1779488249603_zex10l`
- ticket_id: `TEAM-439`