### PR TITLE
feat: add GET /api/health endpoint with uptime metric

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime(),
+  });
+}


### PR DESCRIPTION
## Summary
Adds a health check endpoint at `GET /api/health` that returns system status, timestamp, and uptime.

## Changes
- **New file**: `src/app/api/health/route.ts`

## Response Format
```json
{
  "status": "ok",
  "timestamp": "2024-01-01T00:00:00.000Z",
  "uptime": 123.456
}
```

## Acceptance Criteria
- ✅ GET `/api/health` returns HTTP 200
- ✅ Response contains `status: "ok"` (string literal)
- ✅ Response contains `timestamp` as valid ISO 8601 date string
- ✅ Response contains `uptime` as positive number (seconds)
- ✅ No other HTTP methods are handled (only GET exported)
- ✅ Single file at `src/app/api/health/route.ts`
- ✅ No new dependencies added to package.json

## Ticket
TEAM-38