### PR TITLE
feat(analytics): implement metrics aggregation API route with DynamoDB queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "your-repo",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.600.0",
+    "@aws-sdk/lib-dynamodb": "^3.600.0",
+    "next": "^14.2.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "@types/react": "^18.3.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/src/app/api/analytics/metrics/route.ts
+++ b/src/app/api/analytics/metrics/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { queryEventsForRange } from "@/services/metrics/queryBuilder";
+import {
+  computeDurations,
+  computePerAgentMetrics,
+  computePerWorkflowMetrics,
+  computeSystemWideMetrics,
+} from "@/services/metrics/aggregator";
+import { MetricsResponse, TimeRange } from "@/services/metrics/types";
+
+const rangeSchema = z.enum(["1h", "6h", "24h", "7d"]);
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const rangeParam = searchParams.get("range") ?? "24h";
+
+    const parsed = rangeSchema.safeParse(rangeParam);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: "INVALID_RANGE",
+          message: "range must be one of: 1h, 6h, 24h, 7d",
+        },
+        { status: 400 }
+      );
+    }
+
+    const range: TimeRange = parsed.data;
+    const events = await queryEventsForRange(range);
+    const durations = computeDurations(events);
+
+    const response: MetricsResponse = {
+      range,
+      computedAt: new Date().toISOString(),
+      perAgent: computePerAgentMetrics(events, durations),
+      perWorkflow: computePerWorkflowMetrics(events, durations),
+      systemWide: computeSystemWideMetrics(events, range),
+    };
+
+    return NextResponse.json(response, {
+      headers: {
+        "Cache-Control": "public, max-age=60",
+        "X-Metrics-Computed-At": response.computedAt,
+      },
+    });
+  } catch (error) {
+    console.error("[analytics/metrics] Failed to compute metrics:", error);
+
+    const isThrottling =
+      error instanceof Error &&
+      (error.name === "ProvisionedThroughputExceededException" ||
+        error.name === "ThrottlingException");
+
+    if (isThrottling) {
+      return NextResponse.json(
+        {
+          error: "SERVICE_UNAVAILABLE",
+          message: "Metrics temporarily unavailable due to high load",
+        },
+        { status: 503 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        error: "INTERNAL_ERROR",
+        message: "Failed to compute metrics",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -1,0 +1,8 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+
+const client = new DynamoDBClient({});
+
+export const docClient = DynamoDBDocumentClient.from(client, {
+  marshallOptions: { removeUndefinedValues: true },
+});

--- a/src/services/metrics/aggregator.ts
+++ b/src/services/metrics/aggregator.ts
@@ -1,0 +1,270 @@
+import {
+  DynamoDBEvent,
+  AgentMetrics,
+  WorkflowMetrics,
+  SystemMetrics,
+  DurationPair,
+  TimeRange,
+} from "./types";
+
+const MAX_ITEMS = 100;
+
+const RANGE_HOURS: Record<TimeRange, number> = {
+  "1h": 1,
+  "6h": 6,
+  "24h": 24,
+  "7d": 168,
+};
+
+/**
+ * Match agent.invoked → agent.complete events using FIFO pairing.
+ * Groups events by (agentId + workflowId), sorts by timestamp, then pairs sequentially.
+ * Orphaned invocations (no matching complete) are excluded.
+ * If complete event has a `duration` field, uses that; otherwise computes from timestamps.
+ * Clock skew protection: caps negative durations at 0ms.
+ */
+export function computeDurations(events: DynamoDBEvent[]): DurationPair[] {
+  const grouped = new Map<string, DynamoDBEvent[]>();
+
+  for (const event of events) {
+    if (!event.agentId || !event.workflowId) continue;
+    if (event.eventType !== "agent.invoked" && event.eventType !== "agent.complete") continue;
+    const key = `${event.agentId}::${event.workflowId}`;
+    const group = grouped.get(key) ?? [];
+    group.push(event);
+    grouped.set(key, group);
+  }
+
+  const pairs: DurationPair[] = [];
+
+  for (const [, group] of grouped) {
+    group.sort(
+      (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    );
+
+    const invokeQueue: DynamoDBEvent[] = [];
+
+    for (const event of group) {
+      if (event.eventType === "agent.invoked") {
+        invokeQueue.push(event);
+      } else if (event.eventType === "agent.complete" && invokeQueue.length > 0) {
+        const invoke = invokeQueue.shift()!;
+        const invokeTs = new Date(invoke.timestamp).getTime();
+        const completeTs = new Date(event.timestamp).getTime();
+
+        // Prefer duration field on complete event if available
+        let duration: number;
+        if (event.duration != null && event.duration >= 0) {
+          duration = event.duration;
+        } else {
+          // Clock skew protection: cap at 0ms
+          duration = Math.max(0, completeTs - invokeTs);
+        }
+
+        pairs.push({
+          agentId: event.agentId,
+          workflowId: event.workflowId,
+          invokeTimestamp: invokeTs,
+          completeTimestamp: completeTs,
+          duration,
+        });
+      }
+    }
+  }
+
+  return pairs;
+}
+
+/**
+ * Compute success rate as percentage (0-100).
+ * Only counts agent.complete and agent.error events (excludes in-flight invocations).
+ */
+function computeSuccessRate(events: DynamoDBEvent[]): number {
+  const completions = events.filter(
+    (e) => e.eventType === "agent.complete"
+  ).length;
+  const errors = events.filter((e) => e.eventType === "agent.error").length;
+  const total = completions + errors;
+  if (total === 0) return 0;
+  return Math.round((completions / total) * 10000) / 100; // 2 decimal places
+}
+
+/**
+ * Compute per-agent metrics: invocations, success rate, avg duration, tool usage.
+ * Capped at MAX_ITEMS agents sorted by invocation count descending.
+ */
+export function computePerAgentMetrics(
+  events: DynamoDBEvent[],
+  durations: DurationPair[]
+): AgentMetrics[] {
+  const byAgent = new Map<string, DynamoDBEvent[]>();
+
+  for (const event of events) {
+    if (!event.agentId) continue;
+    const group = byAgent.get(event.agentId) ?? [];
+    group.push(event);
+    byAgent.set(event.agentId, group);
+  }
+
+  const durationsByAgent = new Map<string, number[]>();
+  for (const pair of durations) {
+    const arr = durationsByAgent.get(pair.agentId) ?? [];
+    arr.push(pair.duration);
+    durationsByAgent.set(pair.agentId, arr);
+  }
+
+  const metrics: AgentMetrics[] = [];
+
+  for (const [agentId, agentEvents] of byAgent) {
+    const totalInvocations = agentEvents.filter(
+      (e) => e.eventType === "agent.invoked"
+    ).length;
+
+    const successRate = computeSuccessRate(agentEvents);
+
+    const agentDurations = durationsByAgent.get(agentId) ?? [];
+    const avgDuration =
+      agentDurations.length > 0
+        ? Math.round(agentDurations.reduce((a, b) => a + b, 0) / agentDurations.length)
+        : 0;
+
+    // Count tool usage from events that have a toolName field
+    const toolUsage: Record<string, number> = {};
+    for (const event of agentEvents) {
+      if (event.toolName) {
+        toolUsage[event.toolName] = (toolUsage[event.toolName] ?? 0) + 1;
+      }
+    }
+
+    metrics.push({ agentId, totalInvocations, successRate, avgDuration, toolUsage });
+  }
+
+  // Sort by invocation count descending, cap at MAX_ITEMS
+  metrics.sort((a, b) => b.totalInvocations - a.totalInvocations);
+  return metrics.slice(0, MAX_ITEMS);
+}
+
+/**
+ * Compute per-workflow metrics: time to completion, agent utilization, bottleneck.
+ * Time to completion = last complete timestamp - first invoke timestamp.
+ * Bottleneck = agent with highest average duration in the workflow.
+ * Capped at MAX_ITEMS workflows.
+ */
+export function computePerWorkflowMetrics(
+  events: DynamoDBEvent[],
+  durations: DurationPair[]
+): WorkflowMetrics[] {
+  const byWorkflow = new Map<string, DynamoDBEvent[]>();
+
+  for (const event of events) {
+    if (!event.workflowId) continue;
+    const group = byWorkflow.get(event.workflowId) ?? [];
+    group.push(event);
+    byWorkflow.set(event.workflowId, group);
+  }
+
+  const durationsByWorkflow = new Map<string, DurationPair[]>();
+  for (const pair of durations) {
+    const arr = durationsByWorkflow.get(pair.workflowId) ?? [];
+    arr.push(pair);
+    durationsByWorkflow.set(pair.workflowId, arr);
+  }
+
+  const metrics: WorkflowMetrics[] = [];
+
+  for (const [workflowId, workflowEvents] of byWorkflow) {
+    const uniqueAgents = new Set(workflowEvents.map((e) => e.agentId));
+    const agentUtilization = uniqueAgents.size;
+
+    const wfDurations = durationsByWorkflow.get(workflowId) ?? [];
+
+    // Time to completion: last complete timestamp - first invoke timestamp
+    let timeToCompletion = 0;
+    if (wfDurations.length > 0) {
+      const firstInvoke = Math.min(...wfDurations.map((p) => p.invokeTimestamp));
+      const lastComplete = Math.max(...wfDurations.map((p) => p.completeTimestamp));
+      timeToCompletion = Math.max(0, lastComplete - firstInvoke);
+    }
+
+    // Bottleneck: agent with highest average duration in this workflow
+    let bottleneckAgent = "";
+    if (wfDurations.length > 0) {
+      const agentDurations = new Map<string, number[]>();
+      for (const pair of wfDurations) {
+        const arr = agentDurations.get(pair.agentId) ?? [];
+        arr.push(pair.duration);
+        agentDurations.set(pair.agentId, arr);
+      }
+      let maxAvg = 0;
+      for (const [agent, durs] of agentDurations) {
+        const avg = durs.reduce((a, b) => a + b, 0) / durs.length;
+        if (avg > maxAvg) {
+          maxAvg = avg;
+          bottleneckAgent = agent;
+        }
+      }
+    }
+
+    metrics.push({ workflowId, timeToCompletion, agentUtilization, bottleneckAgent });
+  }
+
+  return metrics.slice(0, MAX_ITEMS);
+}
+
+/**
+ * Compute system-wide metrics:
+ * - throughputPerHour: completed workflows / hours in range
+ * - errorRateTrend: array of hourly error counts
+ * - mostActiveAgents: top 5 agents by invocation count
+ */
+export function computeSystemWideMetrics(
+  events: DynamoDBEvent[],
+  range: TimeRange
+): SystemMetrics {
+  const totalHours = RANGE_HOURS[range];
+
+  // Throughput = unique workflows with at least one agent.complete / hours in range
+  const completedWorkflows = new Set(
+    events
+      .filter((e) => e.eventType === "agent.complete")
+      .map((e) => e.workflowId)
+  );
+  const throughputPerHour =
+    totalHours > 0
+      ? Math.round((completedWorkflows.size / totalHours) * 100) / 100
+      : 0;
+
+  // Error rate trend: error count per hour bucket
+  const now = Date.now();
+  const errorRateTrend: number[] = [];
+
+  for (let i = totalHours - 1; i >= 0; i--) {
+    const hourStart = now - (i + 1) * 60 * 60 * 1000;
+    const hourEnd = now - i * 60 * 60 * 1000;
+
+    const errorCount = events.filter((e) => {
+      if (e.eventType !== "agent.error") return false;
+      const ts = new Date(e.timestamp).getTime();
+      return ts >= hourStart && ts < hourEnd;
+    }).length;
+
+    errorRateTrend.push(errorCount);
+  }
+
+  // Most active agents: top 5 by invocation count
+  const agentInvocations = new Map<string, number>();
+  for (const event of events) {
+    if (!event.agentId || event.eventType !== "agent.invoked") continue;
+    agentInvocations.set(
+      event.agentId,
+      (agentInvocations.get(event.agentId) ?? 0) + 1
+    );
+  }
+
+  const mostActiveAgents = [...agentInvocations.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([agentId]) => agentId);
+
+  return { throughputPerHour, errorRateTrend, mostActiveAgents };
+}

--- a/src/services/metrics/queryBuilder.ts
+++ b/src/services/metrics/queryBuilder.ts
@@ -1,0 +1,108 @@
+import { QueryCommand, QueryCommandInput } from "@aws-sdk/lib-dynamodb";
+import { docClient } from "@/lib/dynamodb";
+import { DynamoDBEvent, TimeRange } from "./types";
+
+const TABLE_NAME = "agentis-events";
+const GSI_NAME = "gsi-timestamp-eventType";
+const MAX_CONCURRENCY = 8;
+
+const RANGE_HOURS: Record<TimeRange, number> = {
+  "1h": 1,
+  "6h": 6,
+  "24h": 24,
+  "7d": 168,
+};
+
+/**
+ * Generate hourly bucket keys (format: YYYY-MM-DD-HH) for the given time range.
+ * These correspond to the GSI partition key `eventHourBucket`.
+ */
+export function generateHourlyBuckets(range: TimeRange): string[] {
+  const hours = RANGE_HOURS[range];
+  const now = new Date();
+  const buckets: string[] = [];
+
+  for (let i = 0; i < hours; i++) {
+    const d = new Date(now.getTime() - i * 60 * 60 * 1000);
+    const bucket = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}-${String(d.getUTCHours()).padStart(2, "0")}`;
+    buckets.push(bucket);
+  }
+
+  return buckets;
+}
+
+function buildQueryParams(bucket: string, rangeStart: string): QueryCommandInput {
+  return {
+    TableName: TABLE_NAME,
+    IndexName: GSI_NAME,
+    KeyConditionExpression:
+      "eventHourBucket = :bucket AND #ts >= :rangeStart",
+    ExpressionAttributeNames: { "#ts": "timestamp" },
+    ExpressionAttributeValues: {
+      ":bucket": bucket,
+      ":rangeStart": rangeStart,
+    },
+  };
+}
+
+/**
+ * Query a single hourly bucket with automatic pagination to retrieve all items.
+ */
+async function queryBucketWithPagination(
+  bucket: string,
+  rangeStart: string
+): Promise<DynamoDBEvent[]> {
+  const events: DynamoDBEvent[] = [];
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+
+  do {
+    const params: QueryCommandInput = {
+      ...buildQueryParams(bucket, rangeStart),
+      ExclusiveStartKey: exclusiveStartKey,
+    };
+
+    const response = await docClient.send(new QueryCommand(params));
+
+    if (response.Items) {
+      for (const item of response.Items) {
+        // Skip events with missing required fields
+        if (item.eventId && item.agentId && item.workflowId && item.timestamp && item.eventType) {
+          events.push(item as DynamoDBEvent);
+        }
+      }
+    }
+
+    exclusiveStartKey = response.LastEvaluatedKey as
+      | Record<string, unknown>
+      | undefined;
+  } while (exclusiveStartKey);
+
+  return events;
+}
+
+/**
+ * Query all events within the given time range using parallel bucket queries.
+ * Executes queries in batches of MAX_CONCURRENCY to avoid DynamoDB throttling.
+ */
+export async function queryEventsForRange(
+  range: TimeRange
+): Promise<DynamoDBEvent[]> {
+  const buckets = generateHourlyBuckets(range);
+  const rangeStart = new Date(
+    Date.now() - RANGE_HOURS[range] * 60 * 60 * 1000
+  ).toISOString();
+  const allEvents: DynamoDBEvent[] = [];
+
+  // Execute queries in parallel batches
+  for (let i = 0; i < buckets.length; i += MAX_CONCURRENCY) {
+    const batch = buckets.slice(i, i + MAX_CONCURRENCY);
+    const results = await Promise.all(
+      batch.map((bucket) => queryBucketWithPagination(bucket, rangeStart))
+    );
+    for (const events of results) {
+      allEvents.push(...events);
+    }
+  }
+
+  return allEvents;
+}

--- a/src/services/metrics/types.ts
+++ b/src/services/metrics/types.ts
@@ -1,0 +1,51 @@
+export interface DynamoDBEvent {
+  eventId: string;
+  timestamp: string;
+  eventType: string;
+  agentId: string;
+  workflowId: string;
+  eventHourBucket: string;
+  toolName?: string;
+  duration?: number;
+  errorType?: string;
+  errorMessage?: string;
+}
+
+export interface AgentMetrics {
+  agentId: string;
+  totalInvocations: number;
+  successRate: number;
+  avgDuration: number;
+  toolUsage: Record<string, number>;
+}
+
+export interface WorkflowMetrics {
+  workflowId: string;
+  timeToCompletion: number;
+  agentUtilization: number;
+  bottleneckAgent: string;
+}
+
+export interface SystemMetrics {
+  throughputPerHour: number;
+  errorRateTrend: number[];
+  mostActiveAgents: string[];
+}
+
+export interface MetricsResponse {
+  range: "1h" | "6h" | "24h" | "7d";
+  computedAt: string;
+  perAgent: AgentMetrics[];
+  perWorkflow: WorkflowMetrics[];
+  systemWide: SystemMetrics;
+}
+
+export type TimeRange = "1h" | "6h" | "24h" | "7d";
+
+export interface DurationPair {
+  agentId: string;
+  workflowId: string;
+  invokeTimestamp: number;
+  completeTimestamp: number;
+  duration: number;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Implements the analytics metrics aggregation API route (`GET /api/analytics/metrics`) that queries the `agentis-events` DynamoDB table and returns pre-computed metrics JSON.

## Changes

### Files Created

| File | Purpose |
|------|---------|
| `src/app/api/analytics/metrics/route.ts` | Next.js App Router GET handler with zod validation, error handling |
| `src/lib/dynamodb.ts` | DynamoDB DocumentClient singleton |
| `src/services/metrics/types.ts` | TypeScript interfaces for events, response, duration pairs |
| `src/services/metrics/queryBuilder.ts` | Hourly bucket generation, parallel GSI queries (max 8), pagination |
| `src/services/metrics/aggregator.ts` | Duration matching, per-agent/per-workflow/system-wide computations |
| `package.json` | Project dependencies (AWS SDK, Next.js, zod) |
| `tsconfig.json` | Strict-mode TypeScript config with `@/*` path alias |

### API Behavior

- **Endpoint:** `GET /api/analytics/metrics?range={1h|6h|24h|7d}`
- **Default range:** `24h`
- **Invalid range:** Returns `400` with `INVALID_RANGE` error
- **DynamoDB throttling:** Returns `503` with `SERVICE_UNAVAILABLE`
- **Unexpected errors:** Returns `500` with `INTERNAL_ERROR`
- **Empty data:** Returns `200` with zeroed metrics and empty arrays
- **Cache:** `Cache-Control: public, max-age=60`

### Aggregation Logic

1. **Duration matching:** FIFO pairing of `agent.invoked` → `agent.complete` by (agentId + workflowId). Uses `duration` field on complete event when available; falls back to timestamp diff with clock-skew protection (caps at 0ms).
2. **Success rate:** `completions / (completions + errors) × 100` (excludes in-flight invocations)
3. **Per-workflow time to completion:** Last complete timestamp − first invoke timestamp
4. **Bottleneck detection:** Agent with highest average duration per workflow
5. **Throughput:** Unique completed workflows / hours in range
6. **Error trend:** Hourly error counts array

### Edge Cases Handled

- Orphaned invocations (invoked but never completed) → excluded from duration calc
- Events with missing required fields → skipped gracefully
- High cardinality → capped at 100 agents/workflows in response
- DynamoDB throttling → 503 response

## Ticket

Resolves TEAM-23

## Testing Notes

- Integration testing requires DynamoDB Local or actual `agentis-events` table with GSI `gsi-timestamp-eventType`
- Unit tests for aggregation functions can use mock event data