### PR TITLE
feat(TEAM-43): implement keyboard shortcut system with command palette

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "workflow-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^14.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.33",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { CommandPaletteProvider } from "@/components/ui/CommandPalette";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Workflow App",
+  description: "Workflow management application",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <CommandPaletteProvider>
+          {children}
+        </CommandPaletteProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,20 @@
+export default function Home() {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-950 text-white">
+      <div className="text-center space-y-4">
+        <h1 className="text-4xl font-bold">Workflow App</h1>
+        <p className="text-gray-400">
+          Press{" "}
+          <kbd className="px-2 py-1 bg-gray-800 rounded border border-gray-600 text-sm">
+            ⌘K
+          </kbd>{" "}
+          or{" "}
+          <kbd className="px-2 py-1 bg-gray-800 rounded border border-gray-600 text-sm">
+            Ctrl+K
+          </kbd>{" "}
+          to open the command palette
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/components/ui/CommandPalette.tsx
+++ b/src/components/ui/CommandPalette.tsx
@@ -1,0 +1,405 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from "react";
+import {
+  Command,
+  CommandCategory,
+  createDefaultCommands,
+  getPlatformShortcut,
+} from "@/lib/commands";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+
+// --- localStorage helpers ---
+const RECENTS_KEY = "command-palette-recents";
+const MAX_RECENTS = 5;
+
+function getRecents(): string[] {
+  try {
+    const stored = localStorage.getItem(RECENTS_KEY);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch {
+    // localStorage unavailable or corrupted
+  }
+  return [];
+}
+
+function saveRecent(commandId: string): void {
+  try {
+    const recents = getRecents();
+    const updated = [
+      commandId,
+      ...recents.filter((id) => id !== commandId),
+    ].slice(0, MAX_RECENTS);
+    localStorage.setItem(RECENTS_KEY, JSON.stringify(updated));
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+// --- Context ---
+interface CommandPaletteContextValue {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  commands: Command[];
+}
+
+const CommandPaletteContext =
+  createContext<CommandPaletteContextValue | null>(null);
+
+export function useCommandPalette() {
+  const context = useContext(CommandPaletteContext);
+  if (!context) {
+    throw new Error(
+      "useCommandPalette must be used within a CommandPaletteProvider"
+    );
+  }
+  return context;
+}
+
+// --- Provider ---
+export function CommandPaletteProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
+
+  const commands = useMemo(
+    () =>
+      createDefaultCommands({
+        togglePalette: toggle,
+        newWorkflow: () => {
+          console.log("[CommandPalette] New Workflow triggered");
+          window.dispatchEvent(new CustomEvent("command:new-workflow"));
+        },
+        toggleSidebar: () => {
+          console.log("[CommandPalette] Toggle Sidebar triggered");
+          window.dispatchEvent(new CustomEvent("command:toggle-sidebar"));
+        },
+        closePalette: close,
+      }),
+    [toggle, close]
+  );
+
+  useKeyboardShortcuts({ commands });
+
+  const contextValue = useMemo(
+    () => ({ isOpen, open, close, toggle, commands }),
+    [isOpen, open, close, toggle, commands]
+  );
+
+  return (
+    <CommandPaletteContext.Provider value={contextValue}>
+      {children}
+      {isMounted && isOpen && (
+        <CommandPaletteModal commands={commands} onClose={close} />
+      )}
+    </CommandPaletteContext.Provider>
+  );
+}
+
+// --- Modal Component ---
+interface CommandPaletteModalProps {
+  commands: Command[];
+  onClose: () => void;
+}
+
+function CommandPaletteModal({ commands, onClose }: CommandPaletteModalProps) {
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [recentIds, setRecentIds] = useState<string[]>([]);
+  const [platformShortcuts, setPlatformShortcuts] = useState<
+    Record<string, string>
+  >({});
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // Load recents and platform shortcuts on mount (client-side only)
+  useEffect(() => {
+    setRecentIds(getRecents());
+    const shortcuts: Record<string, string> = {};
+    commands.forEach((cmd) => {
+      shortcuts[cmd.id] = getPlatformShortcut(cmd.keybinding);
+    });
+    setPlatformShortcuts(shortcuts);
+  }, [commands]);
+
+  // Auto-focus input
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Focus trap
+  useEffect(() => {
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key === "Tab") {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }
+    };
+    document.addEventListener("keydown", handleTab);
+    return () => document.removeEventListener("keydown", handleTab);
+  }, []);
+
+  // Filter commands by query
+  const filteredCommands = useMemo(() => {
+    if (!query.trim())
+      return commands.filter((c) => c.id !== "close-palette");
+    return commands.filter(
+      (c) =>
+        c.id !== "close-palette" &&
+        c.name.toLowerCase().includes(query.toLowerCase())
+    );
+  }, [commands, query]);
+
+  // Build display list: recents first (when no query), then grouped by category
+  const displayItems = useMemo(() => {
+    const items: { command: Command; section: string }[] = [];
+
+    if (!query.trim()) {
+      const recentCommands = recentIds
+        .map((id) => filteredCommands.find((c) => c.id === id))
+        .filter(Boolean) as Command[];
+
+      recentCommands.forEach((cmd) => {
+        items.push({ command: cmd, section: "Recent" });
+      });
+    }
+
+    const categories: CommandCategory[] = ["Navigation", "Actions", "View"];
+    for (const category of categories) {
+      const categoryCommands = filteredCommands.filter(
+        (c) => c.category === category
+      );
+      categoryCommands.forEach((cmd) => {
+        if (
+          !query.trim() &&
+          recentIds.includes(cmd.id) &&
+          items.find((i) => i.command.id === cmd.id)
+        ) {
+          return;
+        }
+        items.push({ command: cmd, section: category });
+      });
+    }
+
+    return items;
+  }, [filteredCommands, recentIds, query]);
+
+  // Reset active index when results change
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  // Execute command
+  const executeCommand = useCallback(
+    (command: Command) => {
+      saveRecent(command.id);
+      onClose();
+      setTimeout(() => command.action(), 0);
+    },
+    [onClose]
+  );
+
+  // Keyboard navigation within palette
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setActiveIndex((prev) =>
+          Math.min(prev + 1, displayItems.length - 1)
+        );
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setActiveIndex((prev) => Math.max(prev - 1, 0));
+        break;
+      case "Enter":
+        e.preventDefault();
+        if (displayItems[activeIndex]) {
+          executeCommand(displayItems[activeIndex].command);
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        onClose();
+        break;
+    }
+  };
+
+  // Scroll active item into view
+  useEffect(() => {
+    const activeEl = listRef.current?.querySelector(
+      `[data-index="${activeIndex}"]`
+    );
+    activeEl?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
+  // Click overlay to close
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === overlayRef.current) {
+      onClose();
+    }
+  };
+
+  // Highlight matched text
+  const highlightMatch = (text: string, search: string) => {
+    if (!search.trim()) return <span>{text}</span>;
+
+    const lowerText = text.toLowerCase();
+    const lowerSearch = search.toLowerCase();
+    const index = lowerText.indexOf(lowerSearch);
+
+    if (index === -1) return <span>{text}</span>;
+
+    return (
+      <span>
+        {text.slice(0, index)}
+        <mark className="bg-yellow-300/30 text-inherit rounded-sm px-0.5">
+          {text.slice(index, index + search.length)}
+        </mark>
+        {text.slice(index + search.length)}
+      </span>
+    );
+  };
+
+  let lastSection = "";
+
+  return (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[20vh] bg-black/50 backdrop-blur-sm"
+      onClick={handleOverlayClick}
+      role="dialog"
+      aria-label="Command palette"
+      aria-modal="true"
+    >
+      <div className="w-full max-w-lg bg-gray-900 rounded-xl shadow-2xl border border-gray-700 overflow-hidden">
+        {/* Search Input */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-700">
+          <svg
+            className="w-5 h-5 text-gray-400 shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+          <input
+            ref={inputRef}
+            type="text"
+            className="flex-1 bg-transparent text-white placeholder-gray-400 outline-none text-sm"
+            placeholder="Type a command or search..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            aria-label="Search commands"
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <kbd className="hidden sm:inline-flex items-center px-2 py-0.5 text-xs text-gray-400 bg-gray-800 rounded border border-gray-600">
+            Esc
+          </kbd>
+        </div>
+
+        {/* Results */}
+        <div
+          ref={listRef}
+          className="max-h-[300px] overflow-y-auto py-2"
+          role="listbox"
+          aria-label="Command results"
+        >
+          {displayItems.length === 0 && (
+            <div className="px-4 py-8 text-center text-sm text-gray-400">
+              No commands found
+            </div>
+          )}
+          {displayItems.map((item, index) => {
+            const showSectionHeader = item.section !== lastSection;
+            lastSection = item.section;
+
+            return (
+              <React.Fragment key={item.command.id + "-" + item.section}>
+                {showSectionHeader && (
+                  <div className="px-4 pt-3 pb-1 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                    {item.section}
+                  </div>
+                )}
+                <div
+                  data-index={index}
+                  className={`flex items-center justify-between px-4 py-2 mx-2 rounded-lg cursor-pointer transition-colors ${
+                    index === activeIndex
+                      ? "bg-gray-700/80 text-white"
+                      : "text-gray-300 hover:bg-gray-800"
+                  }`}
+                  role="option"
+                  aria-selected={index === activeIndex}
+                  onClick={() => executeCommand(item.command)}
+                  onMouseEnter={() => setActiveIndex(index)}
+                >
+                  <span className="text-sm">
+                    {highlightMatch(item.command.name, query)}
+                  </span>
+                  <kbd className="ml-3 shrink-0 inline-flex items-center px-2 py-0.5 text-xs text-gray-400 bg-gray-800 rounded border border-gray-600">
+                    {platformShortcuts[item.command.id] ||
+                      item.command.shortcut}
+                  </kbd>
+                </div>
+              </React.Fragment>
+            );
+          })}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center gap-4 px-4 py-2 border-t border-gray-700 text-xs text-gray-500">
+          <span className="flex items-center gap-1">
+            <kbd className="px-1.5 py-0.5 bg-gray-800 rounded border border-gray-600">
+              ↑↓
+            </kbd>
+            Navigate
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="px-1.5 py-0.5 bg-gray-800 rounded border border-gray-600">
+              ↵
+            </kbd>
+            Execute
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="px-1.5 py-0.5 bg-gray-800 rounded border border-gray-600">
+              Esc
+            </kbd>
+            Close
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useCallback } from "react";
+import { Command } from "@/lib/commands";
+
+interface UseKeyboardShortcutsOptions {
+  commands: Command[];
+  enabled?: boolean;
+}
+
+export function useKeyboardShortcuts({
+  commands,
+  enabled = true,
+}: UseKeyboardShortcutsOptions) {
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (!enabled) return;
+
+      const target = event.target as HTMLElement;
+      const isInputFocused =
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable;
+
+      for (const command of commands) {
+        const { keybinding } = command;
+
+        const isEscapeBinding =
+          keybinding.length === 1 && keybinding[0] === "escape";
+        const isMetaK =
+          keybinding.includes("meta") && keybinding.includes("k");
+
+        // Skip shortcut processing for input-focused elements (except Esc and Cmd+K)
+        if (isInputFocused && !isEscapeBinding && !isMetaK) {
+          continue;
+        }
+
+        const matches = matchKeybinding(event, keybinding);
+
+        if (matches) {
+          event.preventDefault();
+          event.stopPropagation();
+          command.action();
+          return;
+        }
+      }
+    },
+    [commands, enabled]
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleKeyDown]);
+}
+
+function matchKeybinding(event: KeyboardEvent, keybinding: string[]): boolean {
+  const requiresMeta = keybinding.includes("meta");
+  const requiresShift = keybinding.includes("shift");
+  const requiresAlt = keybinding.includes("alt");
+
+  // Cross-platform: metaKey on Mac, ctrlKey on Win/Linux
+  const metaPressed = event.metaKey || event.ctrlKey;
+
+  if (requiresMeta && !metaPressed) return false;
+  if (!requiresMeta && (event.metaKey || event.ctrlKey)) return false;
+  if (requiresShift && !event.shiftKey) return false;
+  if (requiresAlt && !event.altKey) return false;
+
+  // Get the actual key from the binding (non-modifier keys)
+  const keyPart = keybinding.find(
+    (k) => k !== "meta" && k !== "shift" && k !== "alt"
+  );
+
+  if (!keyPart) return false;
+
+  if (keyPart === "escape") {
+    return event.key === "Escape";
+  }
+
+  return event.key.toLowerCase() === keyPart.toLowerCase();
+}

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -1,0 +1,68 @@
+export type CommandCategory = "Navigation" | "Actions" | "View";
+
+export interface Command {
+  id: string;
+  name: string;
+  shortcut: string;
+  keybinding: string[];
+  action: () => void;
+  category: CommandCategory;
+}
+
+export function createDefaultCommands(actions: {
+  togglePalette: () => void;
+  newWorkflow: () => void;
+  toggleSidebar: () => void;
+  closePalette: () => void;
+}): Command[] {
+  return [
+    {
+      id: "toggle-command-palette",
+      name: "Toggle Command Palette",
+      shortcut: "⌘K",
+      keybinding: ["meta", "k"],
+      action: actions.togglePalette,
+      category: "Navigation",
+    },
+    {
+      id: "new-workflow",
+      name: "New Workflow",
+      shortcut: "⌘N",
+      keybinding: ["meta", "n"],
+      action: actions.newWorkflow,
+      category: "Actions",
+    },
+    {
+      id: "toggle-sidebar",
+      name: "Toggle Sidebar",
+      shortcut: "⌘/",
+      keybinding: ["meta", "/"],
+      action: actions.toggleSidebar,
+      category: "View",
+    },
+    {
+      id: "close-palette",
+      name: "Close / Cancel",
+      shortcut: "Esc",
+      keybinding: ["escape"],
+      action: actions.closePalette,
+      category: "Navigation",
+    },
+  ];
+}
+
+export function getPlatformShortcut(keybinding: string[]): string {
+  const isMac =
+    typeof navigator !== "undefined" &&
+    navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+
+  return keybinding
+    .map((key) => {
+      if (key === "meta") return isMac ? "⌘" : "Ctrl+";
+      if (key === "shift") return isMac ? "⇧" : "Shift+";
+      if (key === "alt") return isMac ? "⌥" : "Alt+";
+      if (key === "escape") return "Esc";
+      return key.toUpperCase();
+    })
+    .join("");
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{"name": "next"}],
+    "paths": {"@/*": ["./src/*"]}
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
# Keyboard Shortcut System with Command Palette\n\n## Summary\nImplements a global keyboard shortcut system with a command palette (Cmd+K / Ctrl+K) for the application.\n\n## Files Created\n\n### Core Implementation\n- **`src/lib/commands.ts`** — Command registry with `Command` interface, `CommandCategory` type, default commands factory, and platform-aware shortcut display\n- **`src/hooks/useKeyboardShortcuts.ts`** — Global keyboard shortcut registration hook with cross-platform modifier key detection\n- **`src/components/ui/CommandPalette.tsx`** — Full command palette UI including:\n  - `CommandPaletteProvider` (context + state management)\n  - `CommandPaletteModal` (search, keyboard nav, recents, accessibility)\n\n### Layout Integration\n- **`src/app/layout.tsx`** — Root layout wrapping children in `CommandPaletteProvider`\n- **`src/app/page.tsx`** — Demo page with shortcut hint\n- **`src/app/globals.css`** — Tailwind directives\n\n### Configuration\n- `package.json`, `tsconfig.json`, `next.config.js`, `tailwind.config.ts`, `postcss.config.js`\n\n## Features\n- ✅ Cmd+K (macOS) / Ctrl+K (Win/Linux) toggles the command palette\n- ✅ Esc closes the palette\n- ✅ Case-insensitive substring search filtering\n- ✅ Matched characters highlighted with `<mark>` element\n- ✅ Commands grouped by category with headers\n- ✅ Arrow keys navigate, Enter executes\n- ✅ Recent commands (last 5) persisted in localStorage\n- ✅ Shortcut hints displayed next to each command\n- ✅ No external UI dependencies (pure React + Tailwind)\n- ✅ Hydration-safe platform detection (renders after mount)\n- ✅ localStorage access wrapped in try/catch\n- ✅ Accessible: focus trap, role=\"dialog\", aria-labels\n- ✅ Input-aware: shortcuts skipped in inputs (except Esc and Cmd+K)\n\n## Ticket\nTEAM-43\n\n## Testing\nManual testing instructions:\n1. Run `npm install && npm run dev`\n2. Press Cmd+K or Ctrl+K — palette should open\n3. Type to filter commands\n4. Use arrow keys to navigate, Enter to execute\n5. Press Esc to close\n6. Execute a command, reopen — it appears in Recent section