### PR TITLE
feat(TEAM-331): Implement Collapsible History Sidebar + Intake Card Enhancements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.next/
+next-env.d.ts
+tsconfig.tsbuildinfo

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "your-repo",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^14.2.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.0",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.0"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+
+export default config;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "Your Repo",
+  description: "Next.js application",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <h1 className="text-4xl font-bold">Hello</h1>
+    </main>
+  );
+}

--- a/src/app/workflow/page.tsx
+++ b/src/app/workflow/page.tsx
@@ -1,0 +1,5 @@
+import { WorkflowBoard } from "@/components/workflow/WorkflowBoard";
+
+export default function WorkflowPage() {
+  return <WorkflowBoard />;
+}

--- a/src/components/workflow/ClipboardPasteButton.tsx
+++ b/src/components/workflow/ClipboardPasteButton.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface ClipboardPasteButtonProps {
+  onImagePasted: (file: File) => void;
+  onError: (message: string) => void;
+  disabled?: boolean;
+}
+
+export default function ClipboardPasteButton({
+  onImagePasted,
+  onError,
+  disabled = false,
+}: ClipboardPasteButtonProps) {
+  const [clipboardSupported, setClipboardSupported] = useState(true);
+
+  useEffect(() => {
+    if (!navigator.clipboard || !navigator.clipboard.read) {
+      setClipboardSupported(false);
+    }
+  }, []);
+
+  async function handlePaste() {
+    try {
+      const items = await navigator.clipboard.read();
+      for (const item of items) {
+        const imageType = item.types.find((t) => t.startsWith("image/"));
+        if (imageType) {
+          const blob = await item.getType(imageType);
+          const ext = imageType.split("/")[1];
+          const file = new File([blob], `pasted-image.${ext}`, {
+            type: imageType,
+          });
+          onImagePasted(file);
+          return;
+        }
+      }
+      onError("No image found in clipboard.");
+    } catch {
+      onError(
+        "Clipboard access denied. Please allow clipboard permissions."
+      );
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handlePaste}
+      disabled={disabled || !clipboardSupported}
+      aria-label="Paste image from clipboard"
+      title={
+        !clipboardSupported
+          ? "Clipboard API not supported in this browser."
+          : undefined
+      }
+      className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border border-gray-200 bg-gray-50 hover:bg-gray-100 text-sm font-medium text-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed mt-3"
+    >
+      <svg
+        className="h-4 w-4 text-gray-500"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+        />
+      </svg>
+      Paste from clipboard
+    </button>
+  );
+}

--- a/src/components/workflow/FileDropZone.tsx
+++ b/src/components/workflow/FileDropZone.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState, useRef, DragEvent, KeyboardEvent } from "react";
+
+interface FileDropZoneProps {
+  onFilesDropped: (files: File[]) => void;
+  onError: (message: string) => void;
+  acceptedTypes: string[];
+  children: React.ReactNode;
+  disabled?: boolean;
+}
+
+export default function FileDropZone({
+  onFilesDropped,
+  onError,
+  acceptedTypes,
+  children,
+  disabled = false,
+}: FileDropZoneProps) {
+  const [dragActive, setDragActive] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function handleDragOver(e: DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!disabled) setDragActive(true);
+  }
+
+  function handleDragLeave(e: DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragActive(false);
+  }
+
+  function handleDrop(e: DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragActive(false);
+    if (disabled) return;
+
+    const files = Array.from(e.dataTransfer.files);
+    const valid: File[] = [];
+    const rejected: File[] = [];
+
+    for (const file of files) {
+      if (acceptedTypes.includes(file.type)) {
+        valid.push(file);
+      } else {
+        rejected.push(file);
+      }
+    }
+
+    if (valid.length > 0) onFilesDropped(valid);
+    if (rejected.length > 0) {
+      const names = rejected.map((f) => f.name).join(", ");
+      onError(
+        `Unsupported file type: ${names}. Only PNG, JPG, GIF, and WebP are accepted.`
+      );
+    }
+  }
+
+  function handleClick() {
+    if (!disabled) inputRef.current?.click();
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleClick();
+    }
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files ? Array.from(e.target.files) : [];
+    if (files.length > 0) onFilesDropped(files);
+    e.target.value = "";
+  }
+
+  return (
+    <div
+      role="region"
+      aria-label="Image upload drop zone. Accepts PNG, JPG, GIF, and WebP files."
+      tabIndex={0}
+      className={`border-2 border-dashed rounded-lg p-8 text-center min-h-[120px] transition-colors cursor-pointer ${
+        dragActive
+          ? "border-blue-500 bg-blue-50"
+          : "border-gray-300 hover:border-indigo-400"
+      }`}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/gif,image/webp"
+        multiple
+        className="hidden"
+        onChange={handleFileChange}
+        disabled={disabled}
+      />
+      <svg
+        className="mx-auto h-10 w-10 text-gray-400 mb-2"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={1.5}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+        />
+      </svg>
+      <p className="text-sm font-medium text-gray-700">
+        Drag &amp; drop images here
+      </p>
+      <p className="text-xs text-gray-500 mt-1">PNG, JPG, GIF, WebP</p>
+      {children}
+    </div>
+  );
+}

--- a/src/components/workflow/HistorySidebar.tsx
+++ b/src/components/workflow/HistorySidebar.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { WorkflowRun, WorkflowStatus } from "@/types/workflow";
+
+interface HistorySidebarProps {
+  runs: WorkflowRun[];
+  activeRunId: string;
+  collapsed: boolean;
+  onToggle: () => void;
+  onSelectRun: (id: string) => void;
+}
+
+function formatDate(date: Date): string {
+  const month = date.toLocaleString("en-US", { month: "short" });
+  const day = date.getDate();
+  const year = date.getFullYear();
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${month} ${day}, ${year} \u2022 ${hours}:${minutes}`;
+}
+
+function StatusIcon({ status }: { status: WorkflowStatus }) {
+  if (status === "success") {
+    return (
+      <svg
+        className="h-3.5 w-3.5"
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          fillRule="evenodd"
+          d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
+          clipRule="evenodd"
+        />
+      </svg>
+    );
+  }
+  if (status === "failed") {
+    return (
+      <svg
+        className="h-3.5 w-3.5"
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          fillRule="evenodd"
+          d="M8 15A7 7 0 108 1a7 7 0 000 14zm2.78-9.78a.75.75 0 00-1.06-1.06L8 5.94 6.28 4.22a.75.75 0 00-1.06 1.06L6.94 7 5.22 8.72a.75.75 0 101.06 1.06L8 8.06l1.72 1.72a.75.75 0 101.06-1.06L9.06 7l1.72-1.78z"
+          clipRule="evenodd"
+        />
+      </svg>
+    );
+  }
+  return (
+    <svg
+      className="h-3.5 w-3.5 animate-spin"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        r="6"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeDasharray="24"
+        strokeDashoffset="8"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function StatusBadge({ status }: { status: WorkflowStatus }) {
+  const colorClasses: Record<WorkflowStatus, string> = {
+    success: "bg-green-100 text-green-700",
+    failed: "bg-red-100 text-red-700",
+    running: "bg-amber-100 text-amber-700",
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${colorClasses[status]}`}
+      aria-label={`Status: ${status}`}
+    >
+      <StatusIcon status={status} />
+      {status}
+    </span>
+  );
+}
+
+function WorkflowRunEntry({
+  run,
+  isActive,
+  onSelect,
+}: {
+  run: WorkflowRun;
+  isActive: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-current={isActive ? "true" : undefined}
+      className={`w-full text-left px-3 py-2.5 ${
+        isActive
+          ? "bg-blue-50 border-l-[3px] border-indigo-500"
+          : "hover:bg-gray-50 border-l-[3px] border-transparent"
+      }`}
+    >
+      <p
+        className={`text-sm font-medium truncate ${
+          isActive ? "text-gray-900" : "text-gray-700"
+        }`}
+      >
+        {run.title}
+      </p>
+      <p className="text-xs text-gray-500 mt-0.5">{formatDate(run.date)}</p>
+      <div className="mt-1">
+        <StatusBadge status={run.status} />
+      </div>
+    </button>
+  );
+}
+
+function SidebarToggle({
+  collapsed,
+  onToggle,
+}: {
+  collapsed: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={!collapsed}
+      aria-controls="history-sidebar"
+      aria-label={collapsed ? "Expand history sidebar" : "Collapse history sidebar"}
+      className="p-1 rounded hover:bg-gray-200 text-gray-500"
+    >
+      {collapsed ? (
+        <svg
+          className="h-5 w-5"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fillRule="evenodd"
+            d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
+            clipRule="evenodd"
+          />
+        </svg>
+      ) : (
+        <svg
+          className="h-5 w-5"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fillRule="evenodd"
+            d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z"
+            clipRule="evenodd"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+function CollapsedRail({
+  runs,
+  activeRunId,
+  onSelectRun,
+}: {
+  runs: WorkflowRun[];
+  activeRunId: string;
+  onSelectRun: (id: string) => void;
+}) {
+  const statusColor: Record<WorkflowStatus, string> = {
+    success: "text-green-700",
+    failed: "text-red-700",
+    running: "text-amber-700",
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-1 pt-2">
+      {runs.map((run) => {
+        const isActive = run.id === activeRunId;
+        return (
+          <button
+            key={run.id}
+            type="button"
+            onClick={() => onSelectRun(run.id)}
+            aria-label={run.title}
+            className={`w-8 h-8 flex items-center justify-center rounded ${
+              isActive
+                ? "bg-blue-50 border-l-[3px] border-indigo-500"
+                : "hover:bg-gray-100"
+            } ${statusColor[run.status]}`}
+          >
+            <StatusIcon status={run.status} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function HistorySidebar({
+  runs,
+  activeRunId,
+  collapsed,
+  onToggle,
+  onSelectRun,
+}: HistorySidebarProps) {
+  return (
+    <aside
+      id="history-sidebar"
+      role="complementary"
+      aria-label="Workflow run history"
+      className={`fixed top-0 left-0 h-full bg-white border-r border-gray-200 ${
+        collapsed ? "w-12" : "w-[280px]"
+      } transition-[width] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] overflow-hidden`}
+    >
+      <div className="flex items-center justify-between px-3 py-3 border-b border-gray-200">
+        <span
+          className={`text-sm font-semibold text-gray-900 ${
+            collapsed
+              ? "opacity-0 pointer-events-none"
+              : "opacity-100"
+          } transition-opacity duration-150 ease-out`}
+        >
+          History
+        </span>
+        <SidebarToggle collapsed={collapsed} onToggle={onToggle} />
+      </div>
+
+      <div
+        className={`${
+          collapsed
+            ? "opacity-0 pointer-events-none"
+            : "opacity-100"
+        } transition-opacity duration-150 ease-out`}
+      >
+        <div className="overflow-y-auto">
+          {runs.map((run) => (
+            <WorkflowRunEntry
+              key={run.id}
+              run={run}
+              isActive={run.id === activeRunId}
+              onSelect={() => onSelectRun(run.id)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {collapsed && (
+        <CollapsedRail
+          runs={runs}
+          activeRunId={activeRunId}
+          onSelectRun={onSelectRun}
+        />
+      )}
+    </aside>
+  );
+}

--- a/src/components/workflow/ImagePreview.tsx
+++ b/src/components/workflow/ImagePreview.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+interface ImagePreviewProps {
+  image: { id: string; previewUrl: string; name: string };
+  onRemove: (imageId: string) => void;
+}
+
+export default function ImagePreview({ image, onRemove }: ImagePreviewProps) {
+  return (
+    <div className="relative max-w-[200px] rounded-md overflow-hidden border border-gray-200">
+      <img
+        src={image.previewUrl}
+        alt={`Preview of ${image.name}`}
+        className="w-full h-auto object-cover aspect-square"
+      />
+      <button
+        type="button"
+        onClick={() => onRemove(image.id)}
+        aria-label={`Remove ${image.name}`}
+        className="absolute top-1 right-1 w-6 h-6 rounded-full bg-black/60 text-white hover:bg-black/80 flex items-center justify-center text-xs leading-none"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}

--- a/src/components/workflow/IntakeCard.tsx
+++ b/src/components/workflow/IntakeCard.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import FileDropZone from "./FileDropZone";
+import ImagePreview from "./ImagePreview";
+import ClipboardPasteButton from "./ClipboardPasteButton";
+
+interface ImageFile {
+  id: string;
+  file: File;
+  previewUrl: string;
+  name: string;
+}
+
+const ACCEPTED_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+
+export default function IntakeCard() {
+  const [images, setImages] = useState<ImageFile[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+
+  useEffect(() => {
+    if (error) {
+      const timer = setTimeout(() => setError(null), 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [error]);
+
+  const onImagesAdded = useCallback((files: File[]) => {
+    const newImages: ImageFile[] = files.map((file) => ({
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+      file,
+      previewUrl: URL.createObjectURL(file),
+      name: file.name,
+    }));
+    setImages((prev) => [...prev, ...newImages]);
+    setAnnouncement(
+      `${files.length} image${files.length > 1 ? "s" : ""} added.`
+    );
+  }, []);
+
+  const onImageRemoved = useCallback((imageId: string) => {
+    setImages((prev) => {
+      const img = prev.find((i) => i.id === imageId);
+      if (img) URL.revokeObjectURL(img.previewUrl);
+      return prev.filter((i) => i.id !== imageId);
+    });
+    setAnnouncement("Image removed.");
+  }, []);
+
+  function onError(message: string) {
+    setError(message);
+  }
+
+  function onErrorDismiss() {
+    setError(null);
+  }
+
+  return (
+    <div>
+      <h1 className="text-lg font-semibold text-gray-900 mb-4">
+        Image Intake
+      </h1>
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-5">
+        <FileDropZone
+          onFilesDropped={onImagesAdded}
+          onError={onError}
+          acceptedTypes={ACCEPTED_TYPES}
+        >
+          <ClipboardPasteButton onImagePasted={(file) => onImagesAdded([file])} onError={onError} />
+        </FileDropZone>
+
+        {error && (
+          <div
+            role="alert"
+            aria-live="polite"
+            className="mt-3 flex items-center gap-2 px-3 py-2 rounded-lg bg-red-50 border border-red-200"
+          >
+            <svg
+              className="h-4 w-4 text-red-500 flex-shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <circle cx="12" cy="12" r="10" />
+              <path strokeLinecap="round" d="M15 9l-6 6M9 9l6 6" />
+            </svg>
+            <span className="text-xs text-red-700 font-medium flex-1">
+              {error}
+            </span>
+            <button
+              type="button"
+              onClick={onErrorDismiss}
+              className="text-red-500 hover:text-red-700 text-sm leading-none"
+              aria-label="Dismiss error"
+            >
+              &times;
+            </button>
+          </div>
+        )}
+
+        {images.length > 0 && (
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3 mt-4">
+            {images.map((image) => (
+              <ImagePreview
+                key={image.id}
+                image={image}
+                onRemove={onImageRemoved}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div aria-live="polite" aria-atomic="true" className="sr-only">
+        {announcement}
+      </div>
+    </div>
+  );
+}

--- a/src/components/workflow/WorkflowBoard.tsx
+++ b/src/components/workflow/WorkflowBoard.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import { useCollapsedState } from "@/hooks/useCollapsedState";
+import { mockWorkflowRuns } from "@/data/mockWorkflowRuns";
+import HistorySidebar from "@/components/workflow/HistorySidebar";
+import IntakeCard from "@/components/workflow/IntakeCard";
+
+export function WorkflowBoard() {
+  const [collapsed, toggle] = useCollapsedState();
+  const [activeRunId, setActiveRunId] = useState<string>(
+    mockWorkflowRuns[0].id
+  );
+
+  return (
+    <div className="flex min-h-screen">
+      <HistorySidebar
+        runs={mockWorkflowRuns}
+        activeRunId={activeRunId}
+        collapsed={collapsed}
+        onToggle={toggle}
+        onSelectRun={setActiveRunId}
+      />
+      <main
+        className={`flex-1 p-6 bg-gray-50 ${
+          collapsed ? "ml-12" : "ml-[280px]"
+        } transition-[margin-left] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]`}
+      >
+        <div className="max-w-2xl mx-auto">
+          <IntakeCard />
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default WorkflowBoard;

--- a/src/data/mockWorkflowRuns.ts
+++ b/src/data/mockWorkflowRuns.ts
@@ -1,0 +1,64 @@
+import { WorkflowRun } from "@/types/workflow";
+
+export const mockWorkflowRuns: WorkflowRun[] = [
+  {
+    id: "run-1",
+    title: "Thumbnail generation",
+    date: new Date("2026-05-28T14:50:00"),
+    status: "running",
+  },
+  {
+    id: "run-2",
+    title: "Product photos batch",
+    date: new Date("2026-05-28T14:32:00"),
+    status: "success",
+  },
+  {
+    id: "run-3",
+    title: "Banner resize workflow",
+    date: new Date("2026-05-27T09:15:00"),
+    status: "success",
+  },
+  {
+    id: "run-4",
+    title: "Logo extraction",
+    date: new Date("2026-05-26T11:00:00"),
+    status: "failed",
+  },
+  {
+    id: "run-5",
+    title: "Watermark removal",
+    date: new Date("2026-05-25T16:45:00"),
+    status: "success",
+  },
+  {
+    id: "run-6",
+    title: "Background replacement",
+    date: new Date("2026-05-24T08:30:00"),
+    status: "success",
+  },
+  {
+    id: "run-7",
+    title: "Batch color correction",
+    date: new Date("2026-05-23T13:20:00"),
+    status: "success",
+  },
+  {
+    id: "run-8",
+    title: "Image compression",
+    date: new Date("2026-05-22T10:00:00"),
+    status: "failed",
+  },
+  {
+    id: "run-9",
+    title: "Format conversion",
+    date: new Date("2026-05-21T15:10:00"),
+    status: "success",
+  },
+  {
+    id: "run-10",
+    title: "Metadata cleanup",
+    date: new Date("2026-05-20T09:45:00"),
+    status: "running",
+  },
+];

--- a/src/hooks/useCollapsedState.ts
+++ b/src/hooks/useCollapsedState.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+
+const STORAGE_KEY = "workflow:sidebar-collapsed";
+
+export function useCollapsedState(): [boolean, () => void] {
+  const [collapsed, setCollapsed] = useState<boolean>(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "true") setCollapsed(true);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      localStorage.setItem(STORAGE_KEY, String(next));
+      return next;
+    });
+  }, []);
+
+  return [collapsed, toggle];
+}

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -1,0 +1,15 @@
+export type WorkflowStatus = "success" | "failed" | "running";
+
+export interface WorkflowRun {
+  id: string;
+  title: string;
+  date: Date;
+  status: WorkflowStatus;
+}
+
+export interface ImageFile {
+  id: string;
+  file: File;
+  previewUrl: string;
+  name: string;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
# TEAM-331: Collapsible History Sidebar + Intake Card Enhancements

## Summary
Implements the complete UI for the workflow page including a collapsible history sidebar and enhanced intake card with drag-and-drop + clipboard paste support.

## Changes

### New Files
| File | Purpose |
|------|---------|
| `src/app/workflow/page.tsx` | Page route rendering WorkflowBoard |
| `src/components/workflow/WorkflowBoard.tsx` | Main container with sidebar + content layout |
| `src/components/workflow/HistorySidebar.tsx` | Collapsible sidebar with 10 mock workflow runs |
| `src/components/workflow/IntakeCard.tsx` | Image intake card with drop zone and previews |
| `src/components/workflow/FileDropZone.tsx` | Drag-and-drop zone with file type validation |
| `src/components/workflow/ImagePreview.tsx` | Thumbnail preview with remove button |
| `src/components/workflow/ClipboardPasteButton.tsx` | Clipboard API paste button |
| `src/types/workflow.ts` | TypeScript interfaces (WorkflowRun, ImageFile, etc.) |
| `src/data/mockWorkflowRuns.ts` | 10 mock workflow runs sorted by date |
| `src/hooks/useCollapsedState.ts` | localStorage-persisted collapse state hook |

### Project Scaffolding
- Next.js 14 with App Router, TypeScript strict mode, Tailwind CSS
- `package.json`, `tsconfig.json`, `tailwind.config.ts`, etc.

## Features Implemented
- ✅ **HistorySidebar** — shows last 10 workflow runs with title, date, and status badge
- ✅ **Toggle button** — with localStorage persistence (`workflow:sidebar-collapsed` key)
- ✅ **Active workflow highlighting** — `bg-blue-50` + indigo left border for active entry
- ✅ **Collapsed rail** — shows status icons with active highlighting when sidebar collapsed
- ✅ **IntakeCard** — drag-and-drop file upload zone (PNG, JPG, GIF, WebP)
- ✅ **File type validation** — rejects non-images with error message
- ✅ **Inline image previews** — grid layout with max 200px thumbnails + remove button
- ✅ **Paste-from-clipboard** — reads clipboard API, shows error if no image
- ✅ **Accessibility** — aria-expanded, aria-controls, aria-current, aria-label, role=alert, aria-live regions
- ✅ **Animations** — 300ms sidebar width transition, 150ms content fade
- ✅ **TypeScript** — strict mode, zero errors with `tsc --noEmit`
- ✅ **ESLint** — passes `next lint`

## Acceptance Criteria Met
- [x] `src/app/workflow/page.tsx` renders sidebar + main content
- [x] `src/components/workflow/WorkflowBoard.tsx` contains the board with intake card
- [x] Sidebar shows 10 mock entries, sorted recent-first
- [x] Toggle persists state in localStorage
- [x] Active run is visually highlighted
- [x] Drag-and-drop accepts images, rejects non-images with error message
- [x] Clipboard paste reads image and displays preview
- [x] All components have proper aria attributes
- [x] TypeScript compiles with no errors
- [x] Code passes ESLint