### PR TITLE
fix(test): use correct Jest config key `setupFilesAfterEnv` [TEAM-1460]

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ const nextJest = require('next/jest');
 const createJestConfig = nextJest({ dir: './' });
 
 const customJestConfig = {
-  setupFilesAfterFramework: ['<rootDir>/jest.setup.ts'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testEnvironment: 'jsdom',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({ dir: './' });
+
+const customJestConfig = {
+  setupFilesAfterFramework: ['<rootDir>/jest.setup.ts'],
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "dashboard-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "dependencies": {
+    "next": "^14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.0",
+    "@testing-library/react": "^14.1.0",
+    "@types/jest": "^29.5.0",
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: 'Dashboard',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,22 @@
+import { TicketBadges } from '@/components/dashboard/TicketBadges';
+
+async function getTicketCounts() {
+  // In a real app, this would call an internal API or database
+  return {
+    open: 12,
+    inProgress: 5,
+    resolved: 8,
+    closed: 23,
+  };
+}
+
+export default async function DashboardPage() {
+  const initialCounts = await getTicketCounts();
+
+  return (
+    <main>
+      <h1>Dashboard</h1>
+      <TicketBadges initialCounts={initialCounts} />
+    </main>
+  );
+}

--- a/src/components/dashboard/TicketBadges.tsx
+++ b/src/components/dashboard/TicketBadges.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+
+interface TicketCounts {
+  open: number;
+  inProgress: number;
+  resolved: number;
+  closed: number;
+}
+
+interface TicketBadgesProps {
+  initialCounts?: TicketCounts;
+}
+
+const defaultCounts: TicketCounts = {
+  open: 0,
+  inProgress: 0,
+  resolved: 0,
+  closed: 0,
+};
+
+export function TicketBadges({ initialCounts }: TicketBadgesProps) {
+  const [counts, setCounts] = useState<TicketCounts>(initialCounts ?? defaultCounts);
+  const [isConnected, setIsConnected] = useState(false);
+
+  useEffect(() => {
+    // SSE subscription to get real-time ticket counts
+    const eventSource = new EventSource('/api/tickets/counts');
+
+    eventSource.onopen = () => {
+      setIsConnected(true);
+    };
+
+    eventSource.onmessage = (event) => {
+      try {
+        const data: TicketCounts = JSON.parse(event.data);
+        setCounts(data);
+      } catch (e) {
+        console.error('Failed to parse ticket counts:', e);
+      }
+    };
+
+    eventSource.onerror = () => {
+      setIsConnected(false);
+    };
+
+    return () => {
+      eventSource.close();
+    };
+  }, []);
+
+  return (
+    <div className="ticket-badges" role="group" aria-label="Ticket counts">
+      <Badge label="Open" count={counts.open} variant="warning" />
+      <Badge label="In Progress" count={counts.inProgress} variant="info" />
+      <Badge label="Resolved" count={counts.resolved} variant="success" />
+      <Badge label="Closed" count={counts.closed} variant="default" />
+      {!isConnected && (
+        <span className="connection-status" aria-live="polite">
+          Reconnecting...
+        </span>
+      )}
+    </div>
+  );
+}
+
+interface BadgeProps {
+  label: string;
+  count: number;
+  variant: 'warning' | 'info' | 'success' | 'default';
+}
+
+function Badge({ label, count, variant }: BadgeProps) {
+  return (
+    <div className={`badge badge--${variant}`} aria-label={`${label}: ${count}`}>
+      <span className="badge__label">{label}</span>
+      <span className="badge__count">{count}</span>
+    </div>
+  );
+}
+
+export default TicketBadges;

--- a/src/components/dashboard/__tests__/TicketBadges.test.tsx
+++ b/src/components/dashboard/__tests__/TicketBadges.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { TicketBadges } from '../TicketBadges';
+
+// Mock EventSource
+class MockEventSource {
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  close = jest.fn();
+
+  constructor(public url: string) {
+    // Simulate delayed connection (SSE takes time)
+    setTimeout(() => {
+      this.onopen?.();
+      this.onmessage?.({
+        data: JSON.stringify({ open: 12, inProgress: 5, resolved: 8, closed: 23 }),
+      } as MessageEvent);
+    }, 100);
+  }
+}
+
+(global as any).EventSource = MockEventSource;
+
+describe('TicketBadges', () => {
+  const initialCounts = {
+    open: 12,
+    inProgress: 5,
+    resolved: 8,
+    closed: 23,
+  };
+
+  it('should render initial counts immediately without showing 0 (regression: hydration race)', () => {
+    // This test verifies that when initialCounts are provided (from SSR),
+    // the component renders them on first paint — NOT 0.
+    // FAILS on main (buggy): component ignores initialCounts, renders 0
+    // PASSES on fix branch: component uses initialCounts as useState initial value
+    render(<TicketBadges initialCounts={initialCounts} />);
+
+    // On first render (before useEffect/SSE), badges should show SSR values
+    const openBadge = screen.getByLabelText('Open: 12');
+    const inProgressBadge = screen.getByLabelText('In Progress: 5');
+    const resolvedBadge = screen.getByLabelText('Resolved: 8');
+    const closedBadge = screen.getByLabelText('Closed: 23');
+
+    expect(openBadge).toBeInTheDocument();
+    expect(inProgressBadge).toBeInTheDocument();
+    expect(resolvedBadge).toBeInTheDocument();
+    expect(closedBadge).toBeInTheDocument();
+  });
+
+  it('should not flash 0 values when initialCounts prop is provided', () => {
+    // FAILS on main: badges show "Open: 0", etc.
+    // PASSES on fix: badges show correct counts immediately
+    render(<TicketBadges initialCounts={initialCounts} />);
+
+    // Verify that NO badge shows 0
+    const badges = screen.getAllByLabelText(/: \d+/);
+    badges.forEach((badge) => {
+      expect(badge.getAttribute('aria-label')).not.toMatch(/: 0$/);
+    });
+  });
+
+  it('should fall back to 0 gracefully when no initialCounts provided', () => {
+    // Both versions pass: without SSR data, showing 0 is acceptable
+    render(<TicketBadges />);
+
+    expect(screen.getByLabelText('Open: 0')).toBeInTheDocument();
+    expect(screen.getByLabelText('In Progress: 0')).toBeInTheDocument();
+    expect(screen.getByLabelText('Resolved: 0')).toBeInTheDocument();
+    expect(screen.getByLabelText('Closed: 0')).toBeInTheDocument();
+  });
+
+  it('should clean up EventSource on unmount', () => {
+    const { unmount } = render(<TicketBadges initialCounts={initialCounts} />);
+    unmount();
+
+    // Verify EventSource.close() was called
+    // (MockEventSource tracks this via jest.fn())
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
# Fix: jest.config.js uses invalid `setupFilesAfterFramework` option

## Problem
In `jest.config.js` on branch `feature/TEAM-1457-frontend-dev` (PR #745), the option `setupFilesAfterFramework` is used, but this is **not a valid Jest config key**. The correct key is `setupFilesAfterEnv`.

This causes `jest.setup.ts` (which imports `@testing-library/jest-dom`) to never load, making `toBeInTheDocument()` undefined. Two tests fail as a result.

## Fix
```diff
 const customJestConfig = {
-  setupFilesAfterFramework: ['<rootDir>/jest.setup.ts'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testEnvironment: 'jsdom',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
 };
```

## Verification
- All 4 tests in `TicketBadges.test.tsx` now pass (`npm test` exits 0)
- This is a test infrastructure fix only — no code logic changes

## Files Changed
| File | Change |
|------|--------|
| `jest.config.js` | `setupFilesAfterFramework` → `setupFilesAfterEnv` |

## Related
- Fixes bug found during QA of TEAM-1457 (PR #745)
- Ticket: TEAM-1460
- Workflow: wf_1780025204707_x8jgii
