### PR TITLE
feat(TEAM-1466): Intake card with drag-and-drop upload, image previews, and clipboard paste

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "your-repo",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^14.2.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Workflow App",
+  description: "Workflow management application",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <h1 className="text-2xl font-bold">Workflow App</h1>
+    </main>
+  );
+}

--- a/src/app/workflow/page.tsx
+++ b/src/app/workflow/page.tsx
@@ -1,0 +1,9 @@
+import WorkflowBoard from '@/components/workflow/WorkflowBoard';
+
+export default function WorkflowPage() {
+  return (
+    <div id="workflow-container" className="min-h-screen p-8">
+      <WorkflowBoard />
+    </div>
+  );
+}

--- a/src/components/workflow/DropZone.tsx
+++ b/src/components/workflow/DropZone.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useRef } from 'react';
+import { DropZoneProps } from './types';
+
+export function DropZone({
+  dragOver,
+  error,
+  disabled,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  onClickBrowse,
+}: DropZoneProps) {
+  const statusRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onClickBrowse();
+    }
+  };
+
+  const baseClasses =
+    'border-2 border-dashed rounded-lg p-6 flex flex-col items-center justify-center gap-2 transition-all duration-200 ease-in-out cursor-pointer min-h-[120px]';
+
+  let stateClasses: string;
+  if (error) {
+    stateClasses = 'border-red-400 bg-red-50';
+  } else if (dragOver) {
+    stateClasses = 'border-blue-500 bg-blue-50 ring-4 ring-blue-100 scale-[1.01]';
+  } else {
+    stateClasses = 'border-gray-300 bg-gray-50 hover:border-gray-400 hover:bg-gray-100';
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label="Drop zone for uploading images. Supported formats: PNG, JPG, GIF, WebP"
+      className={`${baseClasses} ${stateClasses}`}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+      onKeyDown={handleKeyDown}
+      aria-disabled={disabled}
+    >
+      {dragOver ? (
+        <>
+          <svg
+            className="w-8 h-8 text-blue-500 animate-pulse"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
+            />
+          </svg>
+          <p className="text-sm font-medium text-blue-600">Release to upload</p>
+        </>
+      ) : (
+        <>
+          <svg
+            className="w-8 h-8 text-gray-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
+            />
+          </svg>
+          <p className="text-sm font-medium text-gray-600">Drag & drop images here</p>
+          <p className="text-xs text-gray-400">PNG, JPG, GIF, WebP</p>
+        </>
+      )}
+      <div ref={statusRef} aria-live="polite" className="sr-only">
+        {dragOver ? 'Files detected. Release to upload.' : ''}
+      </div>
+    </div>
+  );
+}

--- a/src/components/workflow/ErrorMessage.tsx
+++ b/src/components/workflow/ErrorMessage.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useEffect } from 'react';
+import { ErrorMessageProps } from './types';
+
+export function ErrorMessage({ error, onDismiss }: ErrorMessageProps) {
+  useEffect(() => {
+    const timer = setTimeout(onDismiss, 4000);
+    return () => clearTimeout(timer);
+  }, [error, onDismiss]);
+
+  const isWarning = error.type === 'clipboard-empty';
+
+  const containerClasses = isWarning
+    ? 'flex items-start gap-2 p-3 rounded-md bg-amber-50 border border-amber-200 mt-3'
+    : 'flex items-start gap-2 p-3 rounded-md bg-red-50 border border-red-200 mt-3';
+
+  const iconColor = isWarning ? 'text-amber-500' : 'text-red-500';
+  const textColor = isWarning ? 'text-amber-800' : 'text-red-800';
+
+  return (
+    <div role="alert" aria-live="assertive" className={containerClasses}>
+      {isWarning ? (
+        <svg
+          className={`w-5 h-5 ${iconColor} flex-shrink-0 mt-0.5`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      ) : (
+        <svg
+          className={`w-5 h-5 ${iconColor} flex-shrink-0 mt-0.5`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"
+          />
+        </svg>
+      )}
+      <p className={`text-sm ${textColor} flex-1`}>{error.message}</p>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className={`flex-shrink-0 ${textColor} hover:opacity-70`}
+        aria-label="Dismiss error message"
+      >
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M6 18L18 6M6 6l12 12"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/src/components/workflow/ImagePreviewGrid.tsx
+++ b/src/components/workflow/ImagePreviewGrid.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useRef, useCallback } from 'react';
+import { ImagePreviewGridProps } from './types';
+
+export function ImagePreviewGrid({ images, onRemove }: ImagePreviewGridProps) {
+  const buttonRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+  const setButtonRef = useCallback(
+    (id: string) => (el: HTMLButtonElement | null) => {
+      if (el) {
+        buttonRefs.current.set(id, el);
+      } else {
+        buttonRefs.current.delete(id);
+      }
+    },
+    []
+  );
+
+  const handleRemove = (id: string, index: number) => {
+    onRemove(id);
+    requestAnimationFrame(() => {
+      const remainingIds = images.filter((img) => img.id !== id).map((img) => img.id);
+      const nextIndex = Math.min(index, remainingIds.length - 1);
+      if (nextIndex >= 0) {
+        const nextId = remainingIds[nextIndex];
+        buttonRefs.current.get(nextId)?.focus();
+      }
+    });
+  };
+
+  if (images.length === 0) return null;
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3 mt-4">
+      {images.map((image, index) => (
+        <div
+          key={image.id}
+          className="group relative rounded-md overflow-hidden bg-gray-100 border border-gray-200 shadow-sm hover:shadow-md hover:border-gray-300 aspect-square"
+        >
+          <img
+            src={image.objectUrl}
+            alt={`Uploaded image: ${image.fileName}`}
+            className="object-cover w-full h-full"
+            style={{ maxWidth: '200px', maxHeight: '200px' }}
+          />
+          <button
+            ref={setButtonRef(image.id)}
+            type="button"
+            onClick={() => handleRemove(image.id, index)}
+            className="absolute top-1.5 right-1.5 bg-white/90 rounded-full p-1 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity shadow-sm"
+            aria-label={`Remove image: ${image.fileName}`}
+          >
+            <svg
+              className="w-4 h-4 text-gray-600"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/workflow/IntakeCard.tsx
+++ b/src/components/workflow/IntakeCard.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { IntakeCardProps, UploadedImage, ErrorState } from './types';
+import { DropZone } from './DropZone';
+import { ImagePreviewGrid } from './ImagePreviewGrid';
+import { PasteButton } from './PasteButton';
+import { ErrorMessage } from './ErrorMessage';
+
+const ACCEPTED_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+export function IntakeCard({ cardId, title, onImagesChange }: IntakeCardProps) {
+  const [images, setImages] = useState<UploadedImage[]>([]);
+  const [dragOver, setDragOver] = useState(false);
+  const [error, setError] = useState<ErrorState | null>(null);
+  const [clipboardAvailable, setClipboardAvailable] = useState(false);
+
+  const dragCounter = useRef(0);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const objectUrlsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    setClipboardAvailable(typeof navigator?.clipboard?.read === 'function');
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      objectUrlsRef.current.forEach((url) => URL.revokeObjectURL(url));
+    };
+  }, []);
+
+  useEffect(() => {
+    onImagesChange?.(images);
+  }, [images, onImagesChange]);
+
+  const processFiles = useCallback((files: File[]) => {
+    const invalidType: string[] = [];
+    const tooLarge: string[] = [];
+    const valid: File[] = [];
+
+    for (const file of files) {
+      if (!ACCEPTED_TYPES.includes(file.type)) {
+        invalidType.push(file.name);
+      } else if (file.size > MAX_FILE_SIZE) {
+        tooLarge.push(file.name);
+      } else {
+        valid.push(file);
+      }
+    }
+
+    if (invalidType.length > 0) {
+      setError({
+        type: 'invalid-file-type',
+        message: `Unsupported file type: ${invalidType.join(', ')}. Only PNG, JPG, GIF, and WebP are accepted.`,
+        files: invalidType,
+      });
+      return;
+    }
+
+    if (tooLarge.length > 0) {
+      setError({
+        type: 'file-too-large',
+        message: `File too large: ${tooLarge.join(', ')}. Maximum size is 10MB.`,
+        files: tooLarge,
+      });
+      return;
+    }
+
+    const newImages: UploadedImage[] = valid.map((file) => {
+      const objectUrl = URL.createObjectURL(file);
+      objectUrlsRef.current.add(objectUrl);
+      return {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+        objectUrl,
+        fileName: file.name,
+        fileSize: file.size,
+        mimeType: file.type,
+        uploadedAt: Date.now(),
+      };
+    });
+
+    setImages((prev) => [...prev, ...newImages]);
+    setError(null);
+  }, []);
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounter.current++;
+    setDragOver(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounter.current--;
+    if (dragCounter.current === 0) {
+      setDragOver(false);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounter.current = 0;
+    setDragOver(false);
+
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length > 0) {
+      processFiles(files);
+    }
+  };
+
+  const handleClickBrowse = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    if (files.length > 0) {
+      processFiles(files);
+    }
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handlePaste = async () => {
+    try {
+      const clipboardItems = await navigator.clipboard.read();
+      const imageFiles: File[] = [];
+
+      for (const item of clipboardItems) {
+        for (const type of item.types) {
+          if (ACCEPTED_TYPES.includes(type)) {
+            const blob = await item.getType(type);
+            const file = new File([blob], `pasted-image.${type.split('/')[1]}`, { type });
+            imageFiles.push(file);
+          }
+        }
+      }
+
+      if (imageFiles.length === 0) {
+        setError({
+          type: 'clipboard-empty',
+          message: 'No image found in clipboard. Copy an image first.',
+        });
+        return;
+      }
+
+      processFiles(imageFiles);
+    } catch {
+      setError({
+        type: 'clipboard-empty',
+        message: 'Unable to read clipboard. Make sure you have copied an image.',
+      });
+    }
+  };
+
+  const handleRemove = (id: string) => {
+    setImages((prev) => {
+      const image = prev.find((img) => img.id === id);
+      if (image) {
+        URL.revokeObjectURL(image.objectUrl);
+        objectUrlsRef.current.delete(image.objectUrl);
+      }
+      return prev.filter((img) => img.id !== id);
+    });
+  };
+
+  const handleDismissError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return (
+    <div
+      id={cardId}
+      className="w-full max-w-md bg-white rounded-lg shadow-sm border border-gray-200 p-4"
+    >
+      <h2 className="text-lg font-semibold text-gray-900 mb-3">{title}</h2>
+
+      <DropZone
+        dragOver={dragOver}
+        error={error}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        onClickBrowse={handleClickBrowse}
+      />
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/gif,image/webp"
+        multiple
+        className="hidden"
+        onChange={handleFileInputChange}
+        aria-hidden="true"
+        tabIndex={-1}
+      />
+
+      {error && <ErrorMessage error={error} onDismiss={handleDismissError} />}
+
+      <div className="mt-3">
+        <PasteButton disabled={!clipboardAvailable} onClick={handlePaste} />
+      </div>
+
+      <ImagePreviewGrid images={images} onRemove={handleRemove} />
+    </div>
+  );
+}

--- a/src/components/workflow/PasteButton.tsx
+++ b/src/components/workflow/PasteButton.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { PasteButtonProps } from './types';
+
+export function PasteButton({ disabled, onClick }: PasteButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label="Paste image from clipboard"
+      title={disabled ? 'Clipboard API not available in this browser' : undefined}
+      className={`inline-flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium text-gray-700 bg-white border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
+        disabled
+          ? 'opacity-60 cursor-not-allowed bg-gray-100'
+          : 'hover:bg-gray-50 hover:border-gray-400'
+      }`}
+    >
+      <svg
+        className="w-4 h-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+        />
+      </svg>
+      Paste from clipboard
+    </button>
+  );
+}

--- a/src/components/workflow/WorkflowBoard.tsx
+++ b/src/components/workflow/WorkflowBoard.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { IntakeCard } from './IntakeCard';
+
+export default function WorkflowBoard() {
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <IntakeCard cardId="intake-card-1" title="Upload Images" />
+    </div>
+  );
+}

--- a/src/components/workflow/types.ts
+++ b/src/components/workflow/types.ts
@@ -1,0 +1,50 @@
+export interface UploadedImage {
+  id: string;
+  objectUrl: string;
+  fileName: string;
+  fileSize: number;
+  mimeType: string;
+  uploadedAt: number;
+}
+
+export interface ErrorState {
+  type: 'invalid-file-type' | 'clipboard-empty' | 'file-too-large';
+  message: string;
+  files?: string[];
+}
+
+export interface IntakeCardProps {
+  cardId: string;
+  title: string;
+  onImagesChange?: (images: UploadedImage[]) => void;
+}
+
+export interface DropZoneProps {
+  dragOver: boolean;
+  error: ErrorState | null;
+  disabled?: boolean;
+  onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDragLeave: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDrop: (e: React.DragEvent<HTMLDivElement>) => void;
+  onClickBrowse: () => void;
+}
+
+export interface ImagePreviewGridProps {
+  images: UploadedImage[];
+  onRemove: (id: string) => void;
+}
+
+export interface ImagePreviewItemProps {
+  image: UploadedImage;
+  onRemove: () => void;
+}
+
+export interface PasteButtonProps {
+  disabled: boolean;
+  onClick: () => void;
+}
+
+export interface ErrorMessageProps {
+  error: ErrorState;
+  onDismiss: () => void;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,13 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Implements intake card upload enhancements for the workflow board (TEAM-1466).

### Features Implemented

- **Drag-and-Drop File Upload**: Drop zone with visual feedback on drag-over (blue border, ring, scale animation)
- **File Type Validation**: Accepts PNG, JPG, GIF, WebP only; rejects others with clear error message
- **Multi-File Drop**: Support for dropping multiple files in a single action
- **Inline Image Previews**: Responsive thumbnail grid (max 200px) using `URL.createObjectURL()` for instant rendering
- **Remove/Delete Button**: Per-preview remove button with hover reveal and focus management
- **Clipboard Paste**: "Paste from clipboard" button using `navigator.clipboard.read()` API
- **Clipboard Fallback**: Button disabled/hidden if Clipboard API unavailable, with tooltip explanation
- **Empty Clipboard Handling**: User-facing message when clipboard contains no image data
- **Auto-dismiss Errors**: Error messages dismiss after 4 seconds

### Accessibility (WCAG 2.1 AA)

- Drop zone has `aria-label` describing purpose and supported formats
- `aria-live` region for dynamic status announcements
- All images have `alt` text: `"Uploaded image: {fileName}"`
- Remove buttons have `aria-label`: `"Remove image: {fileName}"`
- Keyboard navigation: Tab to drop zone, Enter/Space to browse files
- Focus management: After removing an image, focus moves to next remove button
- `role="alert"` on error messages

### Technical Details

- React + TypeScript with strict mode
- Next.js 14 with App Router
- Tailwind CSS for styling
- `URL.createObjectURL()` for sub-500ms preview rendering
- Object URLs revoked on unmount and removal (no memory leaks)
- Drag counter pattern for reliable dragenter/dragleave detection
- Client-side only (no server upload) as specified

### Files Added

| File | Purpose |
|------|---------|
| `src/components/workflow/types.ts` | TypeScript interfaces for upload state |
| `src/components/workflow/IntakeCard.tsx` | Main container managing all upload state |
| `src/components/workflow/DropZone.tsx` | Drag-and-drop target with visual states |
| `src/components/workflow/ImagePreviewGrid.tsx` | Responsive thumbnail grid |
| `src/components/workflow/PasteButton.tsx` | Clipboard paste button |
| `src/components/workflow/ErrorMessage.tsx` | Error/warning display |
| `src/components/workflow/WorkflowBoard.tsx` | Board container |
| `src/app/workflow/page.tsx` | Workflow page route |

### Acceptance Criteria Coverage

- ✅ AC-5.1: Drop zone visible with instructional text/icon
- ✅ AC-5.2: Drag-over visual feedback (border + background change)
- ✅ AC-5.3: Image files accepted on drop
- ✅ AC-5.4: Non-image files show error message
- ✅ AC-5.5: Multi-file drop supported
- ✅ AC-6.1: Thumbnails render at max 200px width
- ✅ AC-6.2: Previews appear immediately (no page reload)
- ✅ AC-6.3: Remove button on each preview
- ✅ AC-6.4: Previews in upload order
- ✅ AC-7.1: "Paste from clipboard" button visible
- ✅ AC-7.2: Clipboard read adds image as upload
- ✅ AC-7.3: No-image clipboard shows user message
- ✅ AC-7.4: Pasted images appear in same preview grid
- ✅ AC-7.5: Button disabled if Clipboard API unavailable

### Build Status

- ✅ TypeScript compiles cleanly (`npx tsc --noEmit`)
- ✅ Production build passes (`npm run build`)
